### PR TITLE
Refactor yaku search logic

### DIFF
--- a/src/calculation.rs
+++ b/src/calculation.rs
@@ -6,7 +6,7 @@ use crate::{
     meld::no_open_calls,
     tile::Tile,
     types::{Call, FuReason, HanReason, HandContext, Yaku, Yakuman},
-    yaku::{yaku_in_hand, yakuman_in_hand},
+    yaku::{yaku_in_hand, yakuman_in_hand, Checkable},
 };
 use itertools::{repeat_n, Itertools};
 
@@ -19,7 +19,6 @@ pub struct CalcResult {
     pub remaining: Vec<Tile>,
     pub fu_reasons: Vec<(FuReason, u8)>,
     pub han_reasons: Vec<(HanReason, u8)>,
-    //pub calls: Vec<Call>,
 }
 
 /// Calculates fu and han for all winning hand configurations.

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -199,7 +199,6 @@ pub(crate) fn with_tiles_removed(tiles: &[Tile], tiles_to_remove: &[Tile]) -> Ve
 
 /// Checks if `tiles` contains all tiles in `tiles_to_find`.
 pub(crate) fn has_tiles(tiles: &[Tile], tiles_to_find: &[Tile]) -> bool {
-    //let unique_tiles_to_find: Vec<Tile> = tiles_to_find.sorted().dedup();
     for tile in tiles_to_find.iter().sorted().dedup() {
         let tiles_present = tiles.iter().filter(|&t| t == tile).count();
         let tiles_needed = tiles_to_find.iter().filter(|&t| t == tile).count();

--- a/src/yaku.rs
+++ b/src/yaku.rs
@@ -72,7 +72,6 @@ const YAKUMAN_TO_CHECK: [Yakuman; 12] = [
 
 impl Yaku {
     pub fn han_closed(&self) -> u8 { self.info().han_closed }
-
     pub fn han_open(&self) -> u8 { self.info().han_open }
 
     pub fn is_wind(&self) -> bool {
@@ -88,7 +87,6 @@ impl Yaku {
 
 impl Yakuman {
     pub fn han_closed(&self) -> u8 { self.info().han_closed }
-
     pub fn han_open(&self) -> u8 { self.info().han_open }
 
     fn make_info(

--- a/src/yaku.rs
+++ b/src/yaku.rs
@@ -182,18 +182,18 @@ impl Checkable<Yakuman> for Yakuman {
 
 /// Finds all yaku in the given hand.
 pub fn yaku_in_hand(division: &Division, calls: &Vec<Call>, context: &HandContext) -> Vec<Yaku> {
-    _find_in_hand(&YAKU_TO_CHECK.to_vec(), division, calls, context)
+    _find_in_hand(&YAKU_TO_CHECK, division, calls, context)
 }
 
 /// Finds all yakuman in the given hand.
 pub fn yakuman_in_hand(
     division: &Division, calls: &Vec<Call>, context: &HandContext,
 ) -> Vec<Yakuman> {
-    _find_in_hand(&YAKUMAN_TO_CHECK.to_vec(), division, calls, context)
+    _find_in_hand(&YAKUMAN_TO_CHECK, division, calls, context)
 }
 
 pub fn _find_in_hand<T: Checkable<T> + Clone + PartialEq>(
-    to_check: &Vec<T>, division: &Division, calls: &Vec<Call>, context: &HandContext,
+    to_check: &[T], division: &Division, calls: &Vec<Call>, context: &HandContext,
 ) -> Vec<T> {
     let found: Vec<T> =
         to_check.iter().filter(|&y| y.check(division, calls, context)).cloned().collect();

--- a/src/yaku.rs
+++ b/src/yaku.rs
@@ -70,6 +70,34 @@ const YAKUMAN_TO_CHECK: [Yakuman; 12] = [
     Yakuman::Chiihou,
 ];
 
+impl Yaku {
+    pub fn han_closed(&self) -> u8 { self.info().han_closed }
+
+    pub fn han_open(&self) -> u8 { self.info().han_open }
+
+    pub fn is_wind(&self) -> bool {
+        *self == Yaku::Ton || *self == Yaku::Nan || *self == Yaku::Sha || *self == Yaku::Pei
+    }
+
+    fn make_info(
+        han_closed: u8, han_open: u8, check_func: CheckFunc, supercedes: Vec<Yaku>,
+    ) -> YakuInfo<Yaku> {
+        YakuInfo::<Yaku> { han_closed, han_open, check_func, supercedes }
+    }
+}
+
+impl Yakuman {
+    pub fn han_closed(&self) -> u8 { self.info().han_closed }
+
+    pub fn han_open(&self) -> u8 { self.info().han_open }
+
+    fn make_info(
+        han_closed: u8, han_open: u8, check_func: CheckFunc, supercedes: Vec<Yakuman>,
+    ) -> YakuInfo<Yakuman> {
+        YakuInfo::<Yakuman> { han_closed, han_open, check_func, supercedes }
+    }
+}
+
 pub trait Checkable<T> {
     fn info(&self) -> YakuInfo<T>;
     fn check(&self, division: &Division, calls: &Vec<Call>, context: &HandContext) -> bool;
@@ -125,6 +153,7 @@ impl Checkable<Yaku> for Yaku {
         (self.info().check_func)(division, calls, context)
     }
 }
+
 impl Checkable<Yakuman> for Yakuman {
     fn info(&self) -> YakuInfo<Yakuman> {
         match self {
@@ -148,34 +177,6 @@ impl Checkable<Yakuman> for Yakuman {
 
     fn check(&self, division: &Division, calls: &Vec<Call>, context: &HandContext) -> bool {
         (self.info().check_func)(division, calls, context)
-    }
-}
-
-impl Yaku {
-    pub fn han_closed(&self) -> u8 { self.info().han_closed }
-
-    pub fn han_open(&self) -> u8 { self.info().han_open }
-
-    pub fn is_wind(&self) -> bool {
-        *self == Yaku::Ton || *self == Yaku::Nan || *self == Yaku::Sha || *self == Yaku::Pei
-    }
-
-    fn make_info(
-        han_closed: u8, han_open: u8, check_func: CheckFunc, supercedes: Vec<Yaku>,
-    ) -> YakuInfo<Yaku> {
-        YakuInfo::<Yaku> { han_closed, han_open, check_func, supercedes }
-    }
-}
-
-impl Yakuman {
-    pub fn han_closed(&self) -> u8 { self.info().han_closed }
-
-    pub fn han_open(&self) -> u8 { self.info().han_open }
-
-    fn make_info(
-        han_closed: u8, han_open: u8, check_func: CheckFunc, supercedes: Vec<Yakuman>,
-    ) -> YakuInfo<Yakuman> {
-        YakuInfo::<Yakuman> { han_closed, han_open, check_func, supercedes }
     }
 }
 


### PR DESCRIPTION
Refactor the search logic for yaku and yakuman.

- Combine `YakuInfo` and `YakumanInfo` into a single generic `YakuInfo<T>`.
- Define a new `Checkable` trait and implement it for `Yaku` and `Yakuman`.
- Use `Checkable` to refactor mostly identical search logic for yaku and yakuman.

Also remove a bunch of stray comments in unrelated modules.

Note to self: the Git diff makes this look more confusing than it actually is :/